### PR TITLE
Add region name

### DIFF
--- a/awstestutils/__init__.py
+++ b/awstestutils/__init__.py
@@ -21,9 +21,9 @@ def reduce_logging_output(level=logging.WARN):
     logging.getLogger('boto3').setLevel(level)
 
 
-def clean_test_queues(prefix=TEST_NAME_PREFIX):
+def clean_test_queues(prefix=TEST_NAME_PREFIX, region_name=None):
     """Delete all queues that match a "test" name."""
-    sqs = boto3.resource('sqs')
+    sqs = boto3.resource('sqs', region_name=region_name)
     num_queues = 0
     try:
         for queue in sqs.queues.all():
@@ -34,9 +34,9 @@ def clean_test_queues(prefix=TEST_NAME_PREFIX):
         log.info('deleted %s test queues' % num_queues)
 
 
-def clean_test_topics(prefix=TEST_NAME_PREFIX):
+def clean_test_topics(prefix=TEST_NAME_PREFIX, region_name=None):
     """Delete all topics that match a "test" name."""
-    sns = boto3.resource('sns')
+    sns = boto3.resource('sns', region_name=region_name)
     num_topics = 0
     try:
         for topic in sns.topics.all():
@@ -127,14 +127,14 @@ class LiveTestQueue(LiveTestBoto3Resource):
         >>>   msg.delete()
     """
 
-    def __init__(self):
+    def __init__(self, region_name=None):
         """Setup test manager.
 
-        Assumens boto3 correctly configured.
+        Assumes boto3 correctly configured.
         """
         self.queue = None
         self.queue_name = None
-        self.sqs = boto3.resource('sqs')
+        self.sqs = boto3.resource('sqs', region_name=region_name)
 
     def exists(self, queue_name):
         for queue in self.sqs.queues.all():
@@ -192,17 +192,17 @@ class LiveTestTopicQueue(LiveTestBoto3Resource):
         >>>     print(msgs[0].body)
     """
 
-    def __init__(self):
+    def __init__(self, region_name=None):
         """Setup test manager.
 
-        Assumens boto3 correctly configured.
+        Assumes boto3 correctly configured.
         """
         self.topic = None
         self.topic_name = None
         self.queue = None
         self.queue_name = None
-        self.queue_manager = LiveTestQueue()
-        self.sns = boto3.resource('sns')
+        self.queue_manager = LiveTestQueue(region_name=region_name)
+        self.sns = boto3.resource('sns', region_name=region_name)
 
     def create_queue_policy(self, topic, queue):
         """The queue needs a policy to allow the topic to post to it."""

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup
 setup(
     name = 'awstestutils',
     packages = ['awstestutils'],
-    version = '0.1.5',
+    version = '0.1.6',
     description = 'Artifacts to test dependencies with AWS using boto3',
     license = 'BSD',
 
     url = 'https://github.com/etoccalino/aws-test-utils',
-    download_url = 'https://github.com/etoccalino/aws-test-utils/archive/v0.1.5.zip',
+    download_url = 'https://github.com/etoccalino/aws-test-utils/archive/v0.1.6.zip',
     keywords = ['aws', 'boto3', 'testing', 'tool'],
     long_description=open('README.rst').read(),
 

--- a/tests.py
+++ b/tests.py
@@ -46,6 +46,9 @@ class LiveTestBoto3ResourceTestCase(unittest.TestCase):
 
 class LiveTestQueueTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.region_name = 'us-west-1'
+
     def _count_sqs_queues(self, sqs):
         """Count the number of queues, accounting for latency.
 
@@ -63,12 +66,12 @@ class LiveTestQueueTestCase(unittest.TestCase):
         return left_over_queues
 
     def test_use_queue(self):
-        with LiveTestQueue() as queue:
+        with LiveTestQueue(region_name=self.region_name) as queue:
             queue_url = queue.url
         self.assertTrue('http' in queue_url)
 
     def test_message_in_queue(self):
-        with LiveTestQueue() as queue:
+        with LiveTestQueue(region_name=self.region_name) as queue:
             queue.send_message(MessageBody='test text')
             msgs = queue.receive_messages()
         self.assertEqual(len(msgs), 1)
@@ -76,7 +79,7 @@ class LiveTestQueueTestCase(unittest.TestCase):
 
     def test_deleted_queue(self):
         # Create the queue.
-        live = LiveTestQueue()
+        live = LiveTestQueue(region_name=self.region_name)
         live.__enter__()
 
         # Send a message to trigger queue creation.
@@ -94,13 +97,16 @@ class LiveTestQueueTestCase(unittest.TestCase):
 
 class LiveTestTopicQueueTestCase(unittest.TestCase):
 
+    def setUp(self):
+        self.region_name = 'us-west-1'
+
     def test_use_topic(self):
-        with LiveTestTopicQueue() as (topic, queue):
+        with LiveTestTopicQueue(region_name=self.region_name) as (topic, queue):
             topic_arn = topic.arn
         self.assertTrue('sns' in topic_arn)
 
     def test_create_topic_and_queue(self):
-        live = LiveTestTopicQueue()
+        live = LiveTestTopicQueue(region_name=self.region_name)
         self.assertIsNone(live.topic)
         self.assertIsNone(live.queue)
         self.assertIsNone(live.topic_name)
@@ -121,7 +127,7 @@ class LiveTestTopicQueueTestCase(unittest.TestCase):
         self.assertIsNone(live.queue_name)
 
     def test_message_sent(self):
-        with LiveTestTopicQueue() as (topic, queue):
+        with LiveTestTopicQueue(region_name=self.region_name) as (topic, queue):
             topic.publish(Message='some')
             time.sleep(1)
             msgs = queue.receive_messages()


### PR DESCRIPTION
This PR allows the spectro-plumbing library to pass a region_name parameter during tests.
